### PR TITLE
"abort is not a function" when isDisabled is set to true

### DIFF
--- a/src/cypress/plugin/handlers.js
+++ b/src/cypress/plugin/handlers.js
@@ -107,7 +107,7 @@ function makeHandlers({makeRenderingGridClient, logger = console}) {
   function makeWaitForTestResults(waitForTestResults) {
     return async function() {
       const closePromises = runningTests.filter(getClosePromise).map(getClosePromise);
-      const aborts = runningTests.filter(test => !test.closePromise).map(test => test.abort);
+      const aborts = runningTests.filter(test => test.abort && !test.closePromise).map(test => test.abort);
 
       logger.log(
         `Waiting for test results of ${closePromises.length} closed tests. Going to abort ${


### PR DESCRIPTION
The `makeEyesOpen` function in `@applitools/rendering-grid-client` will return an object with no `abort` property:

``` js
    if (isDisabled) {
      logger.log('openEyes: isDisabled=true, skipping checks');
      return {
        checkWindow: disabledFunc('checkWindow'),
        close: disabledFunc('close'),
      };
    }
```

Therefore, `eyes.cypress` should not assume that property to be always present.

Otherwise, an error `abort is not a function` will be triggered.

This patch checks whether `abort` is set and only calls aborts that are truthy.