### PR TITLE
Applitoos -> Applitools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eyes.Cypress
 
-Applitoos Eyes SDK for [Cypress](https://www.cypress.io/).
+Applitools Eyes SDK for [Cypress](https://www.cypress.io/).
 
 ## Installation
 


### PR DESCRIPTION
This typo is also within the main description at the top of the repo. I can't edit that. 